### PR TITLE
Pass Options and Attributes to Elements

### DIFF
--- a/src/Form/MoneyFieldset.php
+++ b/src/Form/MoneyFieldset.php
@@ -34,15 +34,21 @@ class MoneyFieldset extends Fieldset
     public function setOptions($options) : self
     {
         parent::setOptions($options);
-        $currencyOptions = $this->getOption('currency');
-        $currencyOptions = $currencyOptions['options'] ?? null;
+        $currencyOptions = $this->getOption('currency')['options'] ?? null;
         if (is_iterable($currencyOptions)) {
             $this->currencyElement()->setOptions($currencyOptions);
         }
-        $amountOptions = $this->getOption('amount');
-        $amountOptions = $amountOptions['options'] ?? null;
+        $currencyAttributes = $this->getOption('currency')['attributes'] ?? null;
+        if (is_iterable($currencyAttributes)) {
+            $this->currencyElement()->setAttributes($currencyAttributes);
+        }
+        $amountOptions = $this->getOption('amount')['options'] ?? null;
         if (is_iterable($amountOptions)) {
             $this->amountElement()->setOptions($amountOptions);
+        }
+        $amountAttributes = $this->getOption('amount')['attributes'] ?? null;
+        if (is_iterable($amountAttributes)) {
+            $this->amountElement()->setAttributes($amountAttributes);
         }
         return $this;
     }

--- a/src/Form/MoneyFieldset.php
+++ b/src/Form/MoneyFieldset.php
@@ -29,4 +29,14 @@ class MoneyFieldset extends Fieldset
             new Money(0, $defaultCurrency)
         );
     }
+
+    public function currencyElement() : ElementInterface
+    {
+        return $this->get('currency');
+    }
+
+    public function amountElement() : ElementInterface
+    {
+        return $this->get('amount');
+    }
 }

--- a/src/Form/MoneyFieldset.php
+++ b/src/Form/MoneyFieldset.php
@@ -8,6 +8,7 @@ use Money\Currency;
 use Money\Money;
 use Zend\Form\ElementInterface;
 use Zend\Form\Fieldset;
+use function is_iterable;
 
 class MoneyFieldset extends Fieldset
 {
@@ -28,6 +29,22 @@ class MoneyFieldset extends Fieldset
         $this->setObject(
             new Money(0, $defaultCurrency)
         );
+    }
+
+    public function setOptions($options) : self
+    {
+        parent::setOptions($options);
+        $currencyOptions = $this->getOption('currency');
+        $currencyOptions = $currencyOptions['options'] ?? null;
+        if (is_iterable($currencyOptions)) {
+            $this->currencyElement()->setOptions($currencyOptions);
+        }
+        $amountOptions = $this->getOption('amount');
+        $amountOptions = $amountOptions['options'] ?? null;
+        if (is_iterable($amountOptions)) {
+            $this->amountElement()->setOptions($amountOptions);
+        }
+        return $this;
     }
 
     public function currencyElement() : ElementInterface

--- a/test/Money/Form/FormIntegrationTest.php
+++ b/test/Money/Form/FormIntegrationTest.php
@@ -37,4 +37,34 @@ class FormIntegrationTest extends TestCase
         $this->assertInstanceOf(Money::class, $money);
         $this->assertEquals(100, $money->getAmount());
     }
+
+    public function testElementOptionsAreProvidedToIndividualElements() : void
+    {
+        $container = $this->getContainer();
+        $forms = $container->get('FormElementManager');
+
+        /** @var Form $form */
+        $form = $forms->get(Form::class);
+        $form->add([
+            'name' => 'money',
+            'type' => MoneyFieldset::class,
+            'options' => [
+                'currency' => [
+                    'options' => [
+                        'label' => 'Currency Label',
+                    ],
+                ],
+                'amount' => [
+                    'options' => [
+                        'label' => 'Amount Label',
+                    ],
+                ],
+            ],
+        ]);
+        /** @var MoneyFieldset $fieldset */
+        $fieldset = $form->get('money');
+        $this->assertInstanceOf(MoneyFieldset::class, $fieldset);
+        $this->assertSame('Currency Label', $fieldset->currencyElement()->getLabel());
+        $this->assertSame('Amount Label', $fieldset->amountElement()->getLabel());
+    }
 }

--- a/test/Money/Form/FormIntegrationTest.php
+++ b/test/Money/Form/FormIntegrationTest.php
@@ -38,7 +38,7 @@ class FormIntegrationTest extends TestCase
         $this->assertEquals(100, $money->getAmount());
     }
 
-    public function testElementOptionsAreProvidedToIndividualElements() : void
+    public function testElementOptionsAndAttributesAreProvidedToIndividualElements() : void
     {
         $container = $this->getContainer();
         $forms = $container->get('FormElementManager');
@@ -53,10 +53,16 @@ class FormIntegrationTest extends TestCase
                     'options' => [
                         'label' => 'Currency Label',
                     ],
+                    'attributes' => [
+                        'class' => 'c',
+                    ],
                 ],
                 'amount' => [
                     'options' => [
                         'label' => 'Amount Label',
+                    ],
+                    'attributes' => [
+                        'class' => 'a',
                     ],
                 ],
             ],
@@ -66,5 +72,7 @@ class FormIntegrationTest extends TestCase
         $this->assertInstanceOf(MoneyFieldset::class, $fieldset);
         $this->assertSame('Currency Label', $fieldset->currencyElement()->getLabel());
         $this->assertSame('Amount Label', $fieldset->amountElement()->getLabel());
+        $this->assertSame('c', $fieldset->currencyElement()->getAttribute('class'));
+        $this->assertSame('a', $fieldset->amountElement()->getAttribute('class'));
     }
 }

--- a/test/Money/Form/MoneyFieldsetTest.php
+++ b/test/Money/Form/MoneyFieldsetTest.php
@@ -100,4 +100,18 @@ class MoneyFieldsetTest extends TestCase
         $this->assertEquals('ZAR', $moneyProperty->getCurrency()->getCode());
         $this->assertEquals(12345, $moneyProperty->getAmount());
     }
+
+    public function testRetrievalOfCurrencyElement() : void
+    {
+        $fieldset = $this->fieldset();
+        $currency = $fieldset->currencyElement();
+        $this->assertSame('currency', $currency->getName());
+    }
+
+    public function testRetrievalOfAmountElement() : void
+    {
+        $fieldset = $this->fieldset();
+        $amount = $fieldset->amountElement();
+        $this->assertSame('amount', $amount->getName());
+    }
 }


### PR DESCRIPTION
Provide a way of passing options and attributes to the amount and currency elements via the money fieldset when it's created from a spec.